### PR TITLE
Implement new tab behavior for the file browser

### DIFF
--- a/lua/distant/default.lua
+++ b/lua/distant/default.lua
@@ -52,6 +52,9 @@ local DEFAULT_SETTINGS = {
             --- Keymap to edit the file or directory under the cursor.
             --- @type distant.plugin.settings.Keymap
             edit = '<Return>',
+            -- Keymap to open the file or directory under the cursor in a new tab.
+            -- @type distant.plugin.settings.Keymap
+            tabedit = '<C-t>',
             --- Keymap to display metadata for the file or directory under the cursor.
             --- @type distant.plugin.settings.Keymap
             metadata = 'M',

--- a/lua/distant/editor/open/configurator.lua
+++ b/lua/distant/editor/open/configurator.lua
@@ -82,6 +82,7 @@ function M.configure(opts)
             mapper.apply_mappings(bufnr, {
                 [keymap.copy]     = nav.actions.copy,
                 [keymap.edit]     = nav.actions.edit,
+                [keymap.tabedit]  = nav.actions.tabedit,
                 [keymap.metadata] = nav.actions.metadata,
                 [keymap.newdir]   = nav.actions.mkdir,
                 [keymap.newfile]  = nav.actions.newfile,
@@ -154,6 +155,11 @@ function M.configure(opts)
 
     -- Display the buffer in the specified window, defaulting to current
     if not opts.no_focus then
+        if winnr == -1 then
+            -- TODO: At time of implementation there does not seem to be a lua API to create a new tabpage
+            vim.api.nvim_command('tabedit')
+            winnr = 0
+        end
         vim.api.nvim_win_set_buf(winnr, bufnr)
     end
 

--- a/lua/distant/nav/actions.lua
+++ b/lua/distant/nav/actions.lua
@@ -58,6 +58,14 @@ M.edit = function(opts)
     end
 end
 
+M.tabedit = function(opts)
+    opts = opts or {}
+    opts.bufnr = nil
+    opts.winnr = -1
+
+    M.edit(opts)
+end
+
 --- Displays metadata for the path under the cursor.
 M.metadata = function()
     local client_id = plugin.buf.client_id()


### PR DESCRIPTION
This branch implements a new action for the file browser to allow users to open items in a new tab. 

Unfortunately as of this writing there does not seem to be a clean way to create tabpages via the nvim api. So it is understandable if this branch is blocked until the correct infrastructure is available.