### PR TITLE
Implement DistantOpen autocomplete

### DIFF
--- a/lua/distant/commands/distant_open.lua
+++ b/lua/distant/commands/distant_open.lua
@@ -1,6 +1,8 @@
 local plugin = require('distant')
 local utils = require('distant.commands.utils')
 
+local parent_path = require('distant-core.utils').parent_path
+
 --- DistantOpen path [opt1=... opt2=...]
 --- @param cmd NvimCommand
 local function command(cmd)
@@ -38,6 +40,57 @@ local function command(cmd)
     plugin.editor.open(opts)
 end
 
+local function completion(ArgLead,_,_)
+    local seperator = require('distant-core.utils').seperator()
+
+    -- Helper: String ends with
+    local function _ends_with(str, ending)
+        return ending == "" or str:sub(-ending:len()) == ending
+    end
+
+    -- Helper: Get the last component of a path
+    local function last_component(path)
+        local parts = vim.split(path, seperator)
+        return parts[#parts]
+    end
+
+    local path = ArgLead
+
+    if path == nil or path == '' then
+        path = "."
+    end
+
+    local component
+    if not _ends_with(path, seperator) and path ~= "." then
+        component = last_component(path)
+        path = parent_path(path)
+    end
+
+    local err, payload = plugin.api().read_dir({
+        path = path,
+        depth = 1,
+        absolute = true,
+        canonicalize = true,
+    })
+
+    assert(not err, err)
+    assert(payload)
+
+    local results = {}
+
+    for _, entry in ipairs(payload.entries) do
+        if component == nil or string.match(entry.path, component) then
+            local ending_sep = ""
+            if entry.file_type == 'dir' then
+                ending_sep = seperator
+            end
+            table.insert(results, entry.path .. ending_sep)
+        end
+    end
+
+    return results
+end
+
 --- @type DistantCommand
 local COMMAND = {
     name        = 'DistantOpen',
@@ -45,5 +98,6 @@ local COMMAND = {
     command     = command,
     bang        = true,
     nargs       = '*',
+    complete    = completion,
 }
 return COMMAND

--- a/lua/distant/commands/distant_open.lua
+++ b/lua/distant/commands/distant_open.lua
@@ -43,11 +43,6 @@ end
 local function completion(ArgLead,_,_)
     local seperator = require('distant-core.utils').seperator()
 
-    -- Helper: String ends with
-    local function _ends_with(str, ending)
-        return ending == "" or str:sub(-ending:len()) == ending
-    end
-
     -- Helper: Get the last component of a path
     local function last_component(path)
         local parts = vim.split(path, seperator)
@@ -55,13 +50,12 @@ local function completion(ArgLead,_,_)
     end
 
     local path = ArgLead
-
     if path == nil or path == '' then
         path = "."
     end
 
     local component
-    if not _ends_with(path, seperator) and path ~= "." then
+    if not vim.endswith(path, seperator) and path ~= "." then
         component = last_component(path)
         path = parent_path(path)
     end

--- a/lua/distant/commands/init.lua
+++ b/lua/distant/commands/init.lua
@@ -19,6 +19,7 @@
 --- @field bang? boolean
 --- @field force? boolean
 --- @field nargs? integer|'*'
+--- @field complete? fun(string,string,_):string[]
 
 local log      = require('distant-core').log
 
@@ -58,11 +59,24 @@ local function _initialize()
             table.insert(names, name)
         end
 
+        local complete
+        if cmd.complete then
+            -- Register a global function 
+            local func_name = "DistantCommandComplete_" .. cmd.name
+
+            _G[func_name] = function(ArgLead, CmdLine, CursorPos)
+                return table.concat(cmd.complete(ArgLead, CmdLine, CursorPos), "\n")
+            end
+            -- completion config is a string with name of the global function
+            complete = "custom,v:lua." .. func_name
+        end
+
         for _, name in ipairs(names) do
             vim.api.nvim_create_user_command(name, cmd.command, {
                 desc = cmd.description,
                 bang = cmd.bang,
                 nargs = cmd.nargs,
+                complete = complete,
             })
         end
     end


### PR DESCRIPTION
I have implemented auto complete functionality for the `DistantOpen` command. The autocomplete behavior should align with the command itself i.e. showing contents of the current directory if nothing has been typed.

In order to do this I had to also create a field for the completion handler on the DistantCommand class. During command initialization the completion handler for each command is wrapped in its own global function. The name of this global function is then passed to the vim command creation. This should allow for other commands to have completion handlers implemented in the future.